### PR TITLE
feat: gate the api behind a shared password

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -52,6 +52,12 @@ the treats table, never trusted from the client. One ledger entry per
 treat line ("2× 🍺 Pint"), copied by value, so editing or deleting a treat
 never rewrites history.
 
+**Auth is one shared password, not accounts.** Setting APP_PASSWORD wraps
+the whole API in HTTP basic auth (username `pint`, Hono's built-in
+middleware); unset means open, which is the local-dev mode. A login page
+and sessions would be more polish for zero extra safety at single-user
+scale. Revisit only if the app goes multi-user.
+
 **SQLite as a file.** No database server. `apps/api/data/pint-points.db` is
 created on first run (gitignored). Tables are created with
 `CREATE TABLE IF NOT EXISTS` at startup, which is fine while the schema is

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,6 +4,10 @@
 STRAVA_CLIENT_ID=
 STRAVA_CLIENT_SECRET=
 
+# Protects the whole API behind HTTP basic auth (username: pint).
+# Leave empty for local dev. REQUIRED before deploying anywhere public.
+APP_PASSWORD=
+
 # Where the web app runs in dev (used for the post-OAuth redirect)
 WEB_URL=http://localhost:5173
 # Where this API runs (used to build the OAuth callback URL)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
+import { basicAuth } from "hono/basic-auth";
 import { desc, eq, sql } from "drizzle-orm";
 import { MAX_TREATS, SPORT_METRICS } from "@pint-points/shared";
 import type {
@@ -17,6 +18,15 @@ import { computePoints } from "./points.js";
 import { authorizeUrl, exchangeCode, fetchActivities, stravaConfigured } from "./strava.js";
 
 const app = new Hono().basePath("/api");
+
+// Single-user gate: one shared password, browser-native prompt. No
+// APP_PASSWORD means no auth, which is the local-dev mode. Set it in
+// production; without it the API is open to anyone who finds the URL.
+const appPassword = process.env.APP_PASSWORD;
+if (appPassword) {
+  app.use("*", basicAuth({ username: "pint", password: appPassword }));
+}
+
 const now = () => Math.floor(Date.now() / 1000);
 const webUrl = () => process.env.WEB_URL ?? "http://localhost:5173";
 
@@ -393,9 +403,12 @@ app.delete("/treats/:id", (c) => {
   return c.body(null, 204);
 });
 
-const port = 8787;
+const port = Number(process.env.PORT) || 8787;
 serve({ fetch: app.fetch, port });
 console.log(`pint-points api listening on http://localhost:${port}`);
+if (!appPassword) {
+  console.log("⚠ APP_PASSWORD not set. Auth is off; fine locally, not in production.");
+}
 if (!stravaConfigured()) {
   console.log("⚠ Strava credentials not set. Copy .env.example to .env to enable connect/sync.");
 }


### PR DESCRIPTION
Setting APP_PASSWORD wraps every /api route in HTTP basic auth (username: pint). Unset means open, which is the local-dev mode; the server logs a warning so it's hard to deploy open by accident. Also makes the port configurable via PORT for hosting platforms.