### PR TITLE
feat: add user menu with theme toggle, move Settings out of tabs

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -51,6 +51,7 @@ app.get("/me", (c) => {
     firstname: user?.firstname ?? null,
     lastname: user?.lastname ?? null,
     profile: user?.profile ?? null,
+    stravaAthleteId: user?.stravaAthleteId ?? null,
     lastSyncAt: user?.lastSyncAt ?? null,
     startDate: user?.startDate ?? null,
     balance: getBalance(),

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>pint points</title>
+    <title>Pint Points</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,12 +4,12 @@ import Dashboard from "./pages/Dashboard";
 import Points from "./pages/Points";
 import Activities from "./pages/Activities";
 import Settings from "./pages/Settings";
+import { UserMenu } from "./components/UserMenu";
 
 const tabs = [
   { to: "/", label: "Dashboard" },
   { to: "/activities", label: "Activities" },
   { to: "/points", label: "Points" },
-  { to: "/settings", label: "Settings" },
 ];
 
 export default function App() {
@@ -19,32 +19,35 @@ export default function App() {
     <AppShell header={{ height: 60 }} padding="md">
       <AppShell.Header>
         <Container size="sm" h="100%">
-          <Group h="100%" gap="xl">
-            <Title
-              order={3}
-              component={Link}
-              to="/"
-              style={{ textDecoration: "none", color: "inherit" }}
-            >
-              🍺 pintpoints
-            </Title>
-            <Group gap="xs">
-              {tabs.map((tab) => {
-                const active = pathname === tab.to;
-                return (
-                  <Button
-                    key={tab.to}
-                    component={Link}
-                    to={tab.to}
-                    size="compact-sm"
-                    variant={active ? "light" : "subtle"}
-                    color={active ? "yellow" : "gray"}
-                  >
-                    {tab.label}
-                  </Button>
-                );
-              })}
+          <Group h="100%" justify="space-between">
+            <Group gap="xl">
+              <Title
+                order={3}
+                component={Link}
+                to="/"
+                style={{ textDecoration: "none", color: "inherit" }}
+              >
+                🍺 pintpoints
+              </Title>
+              <Group gap="xs">
+                {tabs.map((tab) => {
+                  const active = pathname === tab.to;
+                  return (
+                    <Button
+                      key={tab.to}
+                      component={Link}
+                      to={tab.to}
+                      size="compact-sm"
+                      variant={active ? "light" : "subtle"}
+                      color={active ? "yellow" : "gray"}
+                    >
+                      {tab.label}
+                    </Button>
+                  );
+                })}
+              </Group>
             </Group>
+            <UserMenu />
           </Group>
         </Container>
       </AppShell.Header>

--- a/apps/web/src/components/TreatsSection.tsx
+++ b/apps/web/src/components/TreatsSection.tsx
@@ -73,7 +73,7 @@ export function TreatsSection() {
             <Group align="flex-end">
               <TextInput
                 label="Treat"
-                placeholder="🍔 Burger"
+                placeholder="Enter treat"
                 value={name}
                 onChange={(e) => setName(e.currentTarget.value)}
                 w={180}

--- a/apps/web/src/components/UserMenu.tsx
+++ b/apps/web/src/components/UserMenu.tsx
@@ -1,0 +1,62 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import {
+  Avatar,
+  Group,
+  Menu,
+  Text,
+  UnstyledButton,
+  useMantineColorScheme,
+} from "@mantine/core";
+import { api } from "../lib/api";
+
+export function UserMenu() {
+  const me = useQuery({ queryKey: ["me"], queryFn: api.me });
+  const { colorScheme, setColorScheme } = useMantineColorScheme();
+  const dark = colorScheme === "dark";
+
+  const name = me.data?.firstname;
+
+  return (
+    <Menu position="bottom-end" width={200}>
+      <Menu.Target>
+        <UnstyledButton aria-label="User menu">
+          <Group gap="xs">
+            <Avatar src={me.data?.profile} radius="xl" size={30} alt={name ?? "User"}>
+              🍺
+            </Avatar>
+            {name && (
+              <Text size="sm" fw={500} visibleFrom="xs">
+                {name}
+              </Text>
+            )}
+          </Group>
+        </UnstyledButton>
+      </Menu.Target>
+      <Menu.Dropdown>
+        {me.data?.connected ? (
+          <Menu.Label>Connected via Strava</Menu.Label>
+        ) : (
+          <Menu.Label>Not connected</Menu.Label>
+        )}
+        {me.data?.stravaAthleteId != null && (
+          <Menu.Item
+            component="a"
+            href={`https://www.strava.com/athletes/${me.data.stravaAthleteId}`}
+            target="_blank"
+            rel="noopener"
+          >
+            Strava profile ↗
+          </Menu.Item>
+        )}
+        <Menu.Item component={Link} to="/settings">
+          Settings
+        </Menu.Item>
+        <Menu.Divider />
+        <Menu.Item onClick={() => setColorScheme(dark ? "light" : "dark")}>
+          {dark ? "Light mode" : "Dark mode"}
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -74,7 +74,14 @@ export default function Dashboard() {
           Balance
         </Text>
         <Group align="baseline" gap="sm" mt={4}>
-          <Text fz={48} fw={700} c="yellow.4" style={{ fontVariantNumeric: "tabular-nums" }}>
+          <Text
+            fz={48}
+            fw={700}
+            style={{
+              fontVariantNumeric: "tabular-nums",
+              color: "light-dark(var(--mantine-color-yellow-8), var(--mantine-color-yellow-4))",
+            }}
+          >
             {balance}
           </Text>
           <Text c="dimmed">

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -109,6 +109,8 @@ export interface Me {
   firstname: string | null;
   lastname: string | null;
   profile: string | null;
+  /** Strava athlete id, for linking to the Strava profile page. */
+  stravaAthleteId: number | null;
   lastSyncAt: number | null;
   /** Unix seconds; activities before this never earn points. Set when Strava connects. */
   startDate: number | null;


### PR DESCRIPTION
The header gets a user section (Strava avatar + first name) with a dropdown: link to the Strava profile, Settings, and a light/dark mode toggle (persisted by Mantine via localStorage). Settings leaves the tab bar; tabs are now content-only (Dashboard, Activities, Points) while utility lives under the avatar. The balance number uses light-dark() so it keeps contrast in light mode.